### PR TITLE
add http/https proxy support, socket5 not test yet

### DIFF
--- a/comiccrawler/core/__init__.py
+++ b/comiccrawler/core/__init__.py
@@ -244,6 +244,7 @@ class Downloader:
 			header=self.get_header(),
 			cookie=self.get_cookie(),
 			done=self.handle_grab,
+			proxy=self.mod.config.get("proxy"),
 			**kwargs
 		)
 	
@@ -253,6 +254,7 @@ class Downloader:
 			header=self.get_header(),
 			cookie=self.get_cookie(),
 			done=self.handle_grab,
+			proxy=self.mod.config.get("proxy"),
 			**kwargs
 		)
 		

--- a/comiccrawler/core/__init__.py
+++ b/comiccrawler/core/__init__.py
@@ -239,26 +239,20 @@ class Downloader:
 		self.mod = mod
 		
 	def html(self, url, **kwargs):
-		proxy = self.mod.config.get("proxy")
-		proxies = {'http': proxy, 'https': proxy} if proxy else None
 		return grabhtml(
 			url,
 			header=self.get_header(),
 			cookie=self.get_cookie(),
 			done=self.handle_grab,
-			proxies=proxies,
 			**kwargs
 		)
 	
 	def img(self, url, **kwargs):
-		proxy = self.mod.config.get("proxy")
-		proxies = {'http': proxy, 'https': proxy} if proxy else None
 		return grabimg(
 			url,
 			header=self.get_header(),
 			cookie=self.get_cookie(),
 			done=self.handle_grab,
-			proxies=proxies,
 			**kwargs
 		)
 		

--- a/comiccrawler/core/__init__.py
+++ b/comiccrawler/core/__init__.py
@@ -239,20 +239,26 @@ class Downloader:
 		self.mod = mod
 		
 	def html(self, url, **kwargs):
+		proxy = self.mod.config.get("proxy")
+		proxies = {'http': proxy, 'https': proxy} if proxy else None
 		return grabhtml(
 			url,
 			header=self.get_header(),
 			cookie=self.get_cookie(),
 			done=self.handle_grab,
+			proxies=proxies,
 			**kwargs
 		)
 	
 	def img(self, url, **kwargs):
+		proxy = self.mod.config.get("proxy")
+		proxies = {'http': proxy, 'https': proxy} if proxy else None
 		return grabimg(
 			url,
 			header=self.get_header(),
 			cookie=self.get_cookie(),
 			done=self.handle_grab,
+			proxies=proxies,
 			**kwargs
 		)
 		

--- a/comiccrawler/core/grabber.py
+++ b/comiccrawler/core/grabber.py
@@ -50,7 +50,7 @@ def grabber_log(*args):
 		content_write(profile("grabber.log"), pformat(args) + "\n\n", append=True)
 
 sessions = {}
-def grabber(url, header=None, *, referer=None, cookie=None, raise_429=True, params=None, done=None, proxies=None):
+def grabber(url, header=None, *, referer=None, cookie=None, raise_429=True, params=None, done=None):
 	"""Request url, return text or bytes of the content."""
 	_scheme, netloc, _path, _query, _frag = urlsplit(url)
 	
@@ -71,16 +71,16 @@ def grabber(url, header=None, *, referer=None, cookie=None, raise_429=True, para
 		quote_unicode_dict(cookie)
 		requests.utils.add_dict_to_cookiejar(s.cookies, cookie)
 		
-	r = await_(do_request, s, url, params, proxies, raise_429)
+	r = await_(do_request, s, url, params, raise_429)
 	
 	if done:
 		done(s, r)
 	
 	return r
 		
-def do_request(s, url, params, proxies, raise_429):
+def do_request(s, url, params, raise_429):
 	while True:
-		r = s.get(url, timeout=20, params=params, proxies=proxies)
+		r = s.get(url, timeout=20, params=params)
 		grabber_log(url, r.url, r.request.headers, r.headers)
 
 		if r.status_code == 200:

--- a/comiccrawler/core/grabber.py
+++ b/comiccrawler/core/grabber.py
@@ -50,7 +50,7 @@ def grabber_log(*args):
 		content_write(profile("grabber.log"), pformat(args) + "\n\n", append=True)
 
 sessions = {}
-def grabber(url, header=None, *, referer=None, cookie=None, raise_429=True, params=None, done=None):
+def grabber(url, header=None, *, referer=None, cookie=None, raise_429=True, params=None, done=None, proxies=None):
 	"""Request url, return text or bytes of the content."""
 	_scheme, netloc, _path, _query, _frag = urlsplit(url)
 	
@@ -71,16 +71,16 @@ def grabber(url, header=None, *, referer=None, cookie=None, raise_429=True, para
 		quote_unicode_dict(cookie)
 		requests.utils.add_dict_to_cookiejar(s.cookies, cookie)
 		
-	r = await_(do_request, s, url, params, raise_429)
+	r = await_(do_request, s, url, params, proxies, raise_429)
 	
 	if done:
 		done(s, r)
 	
 	return r
 		
-def do_request(s, url, params, raise_429):
+def do_request(s, url, params, proxies, raise_429):
 	while True:
-		r = s.get(url, timeout=20, params=params)
+		r = s.get(url, timeout=20, params=params, proxies=proxies)
 		grabber_log(url, r.url, r.request.headers, r.headers)
 
 		if r.status_code == 200:


### PR DESCRIPTION
Fixes #67 

modify setting.ini:
```
[SF]
proxy = 127.0.0.1:1080
```

shadow socks + python3.5 on windows 10 64bit test passed