### PR TITLE
fix pixiv ajax (maybe?)

### DIFF
--- a/comiccrawler/mods/pixiv.py
+++ b/comiccrawler/mods/pixiv.py
@@ -113,10 +113,14 @@ def get_episodes(html, url):
 		ep_ids.reverse()
 		
 		pre_url = url
-		for i in range(0, len(ep_ids), 48):
+		for page, i in enumerate(range(0, len(ep_ids), 48)):
 			ids = ep_ids[i:i + 48]
-			query = [("ids[]", str(id)) for id in ids] + [("is_manga_top", "0")]
-			new_url = "https://www.pixiv.net/ajax/user/{}/profile/illusts?{}&work_category=illustManga&is_first_page=1".format(
+			query = [("ids[]", str(id)) for id in ids] + [
+				("is_manga_top", "0"),
+				("work_category", "illustManga"),
+				("is_first_page", "1" if page == 0 else "0")
+			]
+			new_url = "https://www.pixiv.net/ajax/user/{}/profile/illusts?{}".format(
 				id, urlencode(query))
 			cache_next_page[pre_url] = new_url
 			pre_url = new_url


### PR DESCRIPTION
Fixes #209

以下網址將 work_category=illustManga 去除就會變成 不正確請求
所以我猜指要補上這一部分就能修正 ajax error 問題

https://www.pixiv.net/ajax/user/32777/profile/illusts?ids%5B%5D=76281594&ids%5B%5D=76252112&ids%5B%5D=76231019&ids%5B%5D=75973257&ids%5B%5D=75898128&ids%5B%5D=75813217&ids%5B%5D=75804525&ids%5B%5D=75783445&ids%5B%5D=75775501&ids%5B%5D=75676592&ids%5B%5D=75673963&ids%5B%5D=75661202&ids%5B%5D=75659104&ids%5B%5D=75645801&ids%5B%5D=75637651&ids%5B%5D=75628616&ids%5B%5D=75628013&ids%5B%5D=75614978&ids%5B%5D=75614170&ids%5B%5D=75603743&ids%5B%5D=75576284&ids%5B%5D=75547923&ids%5B%5D=75546635&ids%5B%5D=75545868&ids%5B%5D=75359767&ids%5B%5D=75359232&ids%5B%5D=75358044&ids%5B%5D=75357053&ids%5B%5D=75343503&ids%5B%5D=75343209&ids%5B%5D=75342693&ids%5B%5D=75342433&ids%5B%5D=75342196&ids%5B%5D=75335225&ids%5B%5D=75334390&ids%5B%5D=75332273&ids%5B%5D=75303613&ids%5B%5D=75301699&ids%5B%5D=75299876&ids%5B%5D=75299180&ids%5B%5D=75298742&ids%5B%5D=75296647&ids%5B%5D=75290530&ids%5B%5D=75251349&ids%5B%5D=75249179&ids%5B%5D=75217704&ids%5B%5D=75216456&ids%5B%5D=75171052&work_category=illustManga&is_first_page=1